### PR TITLE
Add Support for XCTestPlans

### DIFF
--- a/src/commands/run_tests.yml
+++ b/src/commands/run_tests.yml
@@ -36,6 +36,11 @@ parameters:
     type: string
     default: "marathon"
     description: "Output folder"
+  xcTestPlan:
+    type: string
+    default: ""
+    description: >
+      Path to the '.xctestplan' file that provides a list of active and disabled tests
 steps:
   - run:
       name: Run tests using marathon-cloud
@@ -48,4 +53,5 @@ steps:
         ORB_LINK: <<parameters.link>>
         ORB_NAME: <<parameters.runName>>
         ORB_OUTPUT: <<parameters.output>>
+        ORB_XC_TEST_PLAN: <<parameters.xcTestPlan>>
       command: <<include(scripts/run-tests.sh)>>

--- a/src/scripts/run-tests.sh
+++ b/src/scripts/run-tests.sh
@@ -16,5 +16,9 @@ if [ -n "$ORB_NAME" ]; then
     command="$command -name \"$ORB_NAME\""
 fi
 
+if [ -n "$ORB_XC_TEST_PLAN" ]; then
+    command="$command --xctestplan-filter-file \"$ORB_XC_TEST_PLAN\""
+fi
+
 echo "Executing command: $command"
 eval "$command"


### PR DESCRIPTION
This PR introduces support for the `--xctestplan-filter-file` parameter, enabling the setup of test filters for specific test executions in CircleCI.